### PR TITLE
Adds optional deployment SAS

### DIFF
--- a/deploy/arm/azuredeploy.json
+++ b/deploy/arm/azuredeploy.json
@@ -9,10 +9,15 @@
     "createVnet": {
       "type": "bool",
       "defaultValue": true
+    },
+    "deploymentSas": {
+      "type": "securestring",
+      "defaultValue": ""
     }
   },
   "variables": {
-    "assetsBaseUrl": "[if(empty(parameters('assetsBaseUrl')), if(contains(deployment().properties, 'templateLink'), uri(deployment().properties.templateLink.uri, '../'), 'https://raw.githubusercontent.com/microsoft/secure-data-sandbox/main/deploy/'), parameters('assetsBaseUrl'))]"
+    "assetsBaseUrl": "[if(empty(parameters('assetsBaseUrl')), if(contains(deployment().properties, 'templateLink'), uri(deployment().properties.templateLink.uri, '../'), 'https://raw.githubusercontent.com/microsoft/secure-data-sandbox/main/deploy/'), parameters('assetsBaseUrl'))]",
+    "deploymentSas": "[if(empty(parameters('deploymentSas')), '', concat('?', parameters('deploymentSas')))]"
   },
   "resources": [
     {
@@ -28,7 +33,7 @@
           }
         },
         "templateLink": {
-          "uri": "[uri(variables('assetsBaseUrl'), './arm/network.json')]"
+          "uri": "[concat(uri(variables('assetsBaseUrl'), './arm/network.json'), variables('deploymentSas'))]"
         }
       }
     },
@@ -51,7 +56,7 @@
           }
         },
         "templateLink": {
-          "uri": "[uri(variables('assetsBaseUrl'), './arm/queue.json')]"
+          "uri": "[concat(uri(variables('assetsBaseUrl'), './arm/queue.json'), variables('deploymentSas'))]"
         }
       }
     },
@@ -74,7 +79,7 @@
           }
         },
         "templateLink": {
-          "uri": "[uri(variables('assetsBaseUrl'), './arm/acr.json')]"
+          "uri": "[concat(uri(variables('assetsBaseUrl'), './arm/acr.json'), variables('deploymentSas'))]"
         }
       }
     },
@@ -94,7 +99,7 @@
           }
         },
         "templateLink": {
-          "uri": "[uri(variables('assetsBaseUrl'), './arm/laboratory.json')]"
+          "uri": "[concat(uri(variables('assetsBaseUrl'), './arm/laboratory.json'), variables('deploymentSas'))]"
         }
       }
     },
@@ -117,7 +122,7 @@
           }
         },
         "templateLink": {
-          "uri": "[uri(variables('assetsBaseUrl'), './arm/worker.json')]"
+          "uri": "[concat(uri(variables('assetsBaseUrl'), './arm/worker.json'), variables('deploymentSas'))]"
         }
       }
     },
@@ -153,7 +158,7 @@
           }
         },
         "templateLink": {
-          "uri": "[uri(variables('assetsBaseUrl'), './arm/rbac.json')]"
+          "uri": "[concat(uri(variables('assetsBaseUrl'), './arm/rbac.json'), variables('deploymentSas'))]"
         }
       }
     }


### PR DESCRIPTION
When deploying ARM templates from Azure Storage, either the blobs need to be publicly available, or the URL needs to specify a SAS token so that Azure Resource Manager can pull the nested templates.

This PR adds the optional SAS and has been manually tested to work in both dev and CI environments