### PR TITLE
feat: add azure files integration

### DIFF
--- a/deploy/helm/templates/azurefiles-csi.yaml
+++ b/deploy/helm/templates/azurefiles-csi.yaml
@@ -2,7 +2,14 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: azurefile-csi
-provisioner: kubernetes.io/azure-file
+provisioner: file.csi.azure.com
+allowVolumeExpansion: true
+parameters:
+  skuName: Standard_LRS  # available values: Standard_LRS, Standard_GRS, Standard_ZRS, Standard_RAGRS, Premium_LRS
+  resourceGroup: {{ .Values.worker.resourceGroup }}
+  storageAccount: {{ .Values.worker.storageAccount }}
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
 mountOptions:
   - dir_mode=0777
   - file_mode=0777
@@ -10,5 +17,3 @@ mountOptions:
   - gid=0
   - mfsymlinks
   - cache=strict
-parameters:
-  skuName: Standard_LRS

--- a/deploy/helm/templates/azurefiles-csi.yaml
+++ b/deploy/helm/templates/azurefiles-csi.yaml
@@ -1,0 +1,14 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: azurefile-csi
+provisioner: kubernetes.io/azure-file
+mountOptions:
+  - dir_mode=0777
+  - file_mode=0777
+  - uid=0
+  - gid=0
+  - mfsymlinks
+  - cache=strict
+parameters:
+  skuName: Standard_LRS

--- a/deploy/helm/templates/azurefiles-csi.yaml
+++ b/deploy/helm/templates/azurefiles-csi.yaml
@@ -6,8 +6,8 @@ provisioner: file.csi.azure.com
 allowVolumeExpansion: true
 parameters:
   skuName: Standard_LRS  # available values: Standard_LRS, Standard_GRS, Standard_ZRS, Standard_RAGRS, Premium_LRS
-  resourceGroup: {{ .Values.worker.resourceGroup }}
-  storageAccount: {{ .Values.worker.storageAccount }}
+  resourceGroup: {{ .Values.resourceGroup }}
+  storageAccount: {{ .Values.worker.runsTempStorageAccount }}
 reclaimPolicy: Delete
 volumeBindingMode: Immediate
 mountOptions:

--- a/deploy/helm/values.dev.yaml
+++ b/deploy/helm/values.dev.yaml
@@ -18,6 +18,8 @@ worker:
   image: acanthamoeba/sds-worker
   queueMode: azure
   queueEndpoint: https://<storageaccount>.queue.core.windows.net/runs
+  resourceGroup: resourceGroup
+  storageAccount: storageAccount
 
 # Use Service Principals instead of Managed Identity
 identities:

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -19,6 +19,8 @@ worker:
   image: acanthamoeba/sds-worker
   queueMode: azure
   queueEndpoint: https://<storageaccount>.queue.core.windows.net/runs
+  resourceGroup: resourceGroup
+  storageAccount: storageAccount
 
 identities:
   worker:

--- a/packages/worker/package-lock.json
+++ b/packages/worker/package-lock.json
@@ -3660,6 +3660,11 @@
 				"tweetnacl": "~0.14.0"
 			}
 		},
+		"stream-buffers": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-3.0.2.tgz",
+			"integrity": "sha512-DQi1h8VEBA/lURbSwFtEHnSTb9s2/pwLEaFuNhXwy1Dx3Sa0lOuYT2yNUr4/j2fs8oCAMANtrZ5OrPZtyVs3MQ=="
+		},
 		"strict-uri-encode": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "@kubernetes/client-node": "^0.12.0",
-    "@microsoft/sds": "*"
+    "@microsoft/sds": "*",
+    "stream-buffers": "^3.0.2"
   }
 }

--- a/packages/worker/src/argoWorker.ts
+++ b/packages/worker/src/argoWorker.ts
@@ -104,6 +104,7 @@ export function createWorkflow(run: PipelineRun): Workflow {
               },
               spec: {
                 // TODO: Set this as a parameter
+                storageClassName: 'azurefile-csi',
                 accessModes: ['ReadWriteOnce'],
                 resources: {
                   requests: {

--- a/packages/worker/test/argoWorker.test.ts
+++ b/packages/worker/test/argoWorker.test.ts
@@ -228,6 +228,7 @@ describe('createWorkflow', () => {
               name: 'images',
             },
             spec: {
+              storageClassName: 'azurefile-csi',
               accessModes: ['ReadWriteOnce'],
               resources: {
                 requests: {
@@ -241,6 +242,7 @@ describe('createWorkflow', () => {
               name: 'predictions',
             },
             spec: {
+              storageClassName: 'azurefile-csi',
               accessModes: ['ReadWriteOnce'],
               resources: {
                 requests: {
@@ -254,6 +256,7 @@ describe('createWorkflow', () => {
               name: 'scores',
             },
             spec: {
+              storageClassName: 'azurefile-csi',
               accessModes: ['ReadWriteOnce'],
               resources: {
                 requests: {


### PR DESCRIPTION
A previous pr added dynamic volume creation based on the volumes in the benchmark. These changes add support for doing that with azure files. Adds a storage class and a reference to the storage class in the generated workflow