### PR TITLE
feat: Add optional properties to the sds suite interface

### DIFF
--- a/packages/cli/src/demo.ts
+++ b/packages/cli/src/demo.ts
@@ -60,17 +60,14 @@ const suite1: ISuite = {
       name: 'training',
       type: 'AzureBlob',
       target: 'https://sample.blob.core.windows.net/training',
-      options: { 
-        dataset: 'datasetId-0000-0000-0000'
+      properties: {
+        datasetId: 'dataset-0000-0000-0000',
       },
     },
     {
       name: 'reference',
       type: 'AzureBlob',
       target: 'https://sample.blob.core.windows.net/reference',
-      options: { 
-        dataset: 'datasetId-0000-0000-0000'
-      },
     },
   ],
 };

--- a/packages/cli/src/demo.ts
+++ b/packages/cli/src/demo.ts
@@ -60,11 +60,17 @@ const suite1: ISuite = {
       name: 'training',
       type: 'AzureBlob',
       target: 'https://sample.blob.core.windows.net/training',
+      options: { 
+        dataset: 'datasetId-0000-0000-0000'
+      },
     },
     {
       name: 'reference',
       type: 'AzureBlob',
       target: 'https://sample.blob.core.windows.net/reference',
+      options: { 
+        dataset: 'datasetId-0000-0000-0000'
+      },
     },
   ],
 };

--- a/packages/sds/src/laboratory/interfaces.ts
+++ b/packages/sds/src/laboratory/interfaces.ts
@@ -152,6 +152,9 @@ const EphemeralSuiteVolumeType = t.intersection([
   t.type({
     name: t.string,
     type: t.literal('ephemeral'),
+    options: t.type({
+      dataset: t.string,
+    }),
   }),
   t.partial({
     target: t.undefined,
@@ -161,6 +164,9 @@ const EphemeralSuiteVolumeType = t.intersection([
 const TargetedSuiteVolumeType = t.type({
   name: t.string,
   type: t.string,
+  options: t.type({
+    dataset: t.string,
+  }),
   target: t.string,
 });
 

--- a/packages/sds/src/laboratory/interfaces.ts
+++ b/packages/sds/src/laboratory/interfaces.ts
@@ -152,9 +152,6 @@ const EphemeralSuiteVolumeType = t.intersection([
   t.type({
     name: t.string,
     type: t.literal('ephemeral'),
-    options: t.type({
-      dataset: t.string,
-    }),
   }),
   t.partial({
     target: t.undefined,
@@ -164,15 +161,14 @@ const EphemeralSuiteVolumeType = t.intersection([
 const TargetedSuiteVolumeType = t.type({
   name: t.string,
   type: t.string,
-  options: t.type({
-    dataset: t.string,
-  }),
   target: t.string,
 });
 
-const SuiteVolumeType = t.union([
-  TargetedSuiteVolumeType,
-  EphemeralSuiteVolumeType,
+const SuiteVolumeType = t.intersection([
+  t.union([TargetedSuiteVolumeType, EphemeralSuiteVolumeType]),
+  t.partial({
+    properties: t.record(t.string, t.string),
+  }),
 ]);
 export type SuiteVolume = t.TypeOf<typeof SuiteVolumeType>;
 

--- a/packages/sds/test/laboratory/data.ts
+++ b/packages/sds/test/laboratory/data.ts
@@ -159,6 +159,9 @@ export const suite1: ISuite = {
       name: 'training',
       type: 'AzureBlob',
       target: 'https://sample.blob.core.windows.net/training',
+      properties: {
+        datasetId: 'dataset-0000-0000-0001',
+      },
     },
     {
       name: 'reference',
@@ -179,6 +182,9 @@ export const suite2: ISuite = {
       name: 'training',
       type: 'AzureBlob',
       target: 'https://sample.blob.core.windows.net/training',
+      properties: {
+        datasetId: 'dataset-0000-0000-0002',
+      },
     },
     {
       name: 'reference',
@@ -199,6 +205,9 @@ export const suite3: ISuite = {
       name: 'training',
       type: 'AzureBlob',
       target: 'https://sample.blob.core.windows.net/training',
+      properties: {
+        datasetId: 'dataset-0000-0000-0003',
+      },
     },
     {
       name: 'reference',


### PR DESCRIPTION
Updated sds suite format to include optional properties, such as a dataset ID. This is an interface update, still need to add implementation to process the options.

Fix AB#4389