### PR TITLE
docs: Updated readme.md with lerna requirement 

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,13 @@ In order to use `SDS` you must have
 [Node](https://nodejs.org/en/download/) installed on your machine.
 `SDS` has been tested with Node version [12.16.3](https://nodejs.org/download/release/v12.16.3/).
 
+You will need [Lerna](https://lerna.js.org/) as a prerequisite.
+
 Here are the steps for cloning and building `SDS`:
 ~~~
 % git clone https://github.com/microsoft/secure-data-sandbox.git
 % npm install
+% lerna bootstrap
 % npm run compile
 ~~~
 


### PR DESCRIPTION
This PR is to add lerna as a requirement on the project. If you clone the project and follow the install instruction it will fail if you don't have lerna installed. The way to fix this is install lerna and executed the lerna bootstrap command before the npm run compile. 