### PR TITLE
feat: Allow mapping of properties into cmd / env

### DIFF
--- a/packages/laboratory/package-lock.json
+++ b/packages/laboratory/package-lock.json
@@ -632,15 +632,6 @@
 			"dev": true,
 			"optional": true
 		},
-		"@types/jsonwebtoken": {
-			"version": "8.5.0",
-			"resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.5.0.tgz",
-			"integrity": "sha512-9bVao7LvyorRGZCw0VmH/dr7Og+NdjYSsKAxB43OQoComFbBgsEpoR9JW6+qSq/ogwVBg8GI2MfAlk4SYI4OLg==",
-			"dev": true,
-			"requires": {
-				"@types/node": "*"
-			}
-		},
 		"@types/mime": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.3.tgz",
@@ -2233,6 +2224,7 @@
 						"has": "^1.0.3",
 						"has-symbols": "^1.0.1",
 						"is-callable": "^1.2.2",
+						"is-negative-zero": "^2.0.0",
 						"is-regex": "^1.1.1",
 						"object-inspect": "^1.8.0",
 						"object-keys": "^1.1.1",
@@ -2247,8 +2239,30 @@
 					"integrity": "sha512-VT/cxmx5yaoHSOTSyrCygIDFco+RsibY2NM0a4RdEeY/4KgqezwFtK1yr3U67xYhqJSlASm2pKhLVzPj2lr4bA==",
 					"requires": {
 						"define-properties": "^1.1.3",
+						"es-abstract": "^1.18.0-next.0",
 						"has-symbols": "^1.0.1",
 						"object-keys": "^1.1.1"
+					},
+					"dependencies": {
+						"es-abstract": {
+							"version": "1.18.0-next.1",
+							"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+							"integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
+							"requires": {
+								"es-to-primitive": "^1.2.1",
+								"function-bind": "^1.1.1",
+								"has": "^1.0.3",
+								"has-symbols": "^1.0.1",
+								"is-callable": "^1.2.2",
+								"is-negative-zero": "^2.0.0",
+								"is-regex": "^1.1.1",
+								"object-inspect": "^1.8.0",
+								"object-keys": "^1.1.1",
+								"object.assign": "^4.1.1",
+								"string.prototype.trimend": "^1.0.1",
+								"string.prototype.trimstart": "^1.0.1"
+							}
+						}
 					}
 				}
 			}
@@ -2314,8 +2328,7 @@
 		"escape-goat": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-2.1.1.tgz",
-			"integrity": "sha512-8/uIhbG12Csjy2JEW7D9pHbreaVaS/OpN3ycnyvElTdwM5n6GY6W6e2IPemfvGZeUMqZ9A/3GqIZMgKnBhAw/Q==",
-			"dev": true
+			"integrity": "sha512-8/uIhbG12Csjy2JEW7D9pHbreaVaS/OpN3ycnyvElTdwM5n6GY6W6e2IPemfvGZeUMqZ9A/3GqIZMgKnBhAw/Q=="
 		},
 		"escape-html": {
 			"version": "1.0.3",
@@ -4660,6 +4673,11 @@
 			"integrity": "sha512-T/S49scO8plUiAOA2DBTBG3JHpn1yiw0kRp6dgiZ0v2/6twi5eiB0rHtHFH9ZIrvlWc6+4O+m4zg5+Z833aXgw==",
 			"dev": true
 		},
+		"is-negative-zero": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.0.tgz",
+			"integrity": "sha1-lVOxIbD6wohp2p7UWeIMdUN4hGE="
+		},
 		"is-npm": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/is-npm/-/is-npm-4.0.0.tgz",
@@ -5024,30 +5042,6 @@
 				"minimist": "^1.2.5"
 			}
 		},
-		"jsonwebtoken": {
-			"version": "8.5.1",
-			"resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
-			"integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
-			"requires": {
-				"jws": "^3.2.2",
-				"lodash.includes": "^4.3.0",
-				"lodash.isboolean": "^3.0.3",
-				"lodash.isinteger": "^4.0.4",
-				"lodash.isnumber": "^3.0.3",
-				"lodash.isplainobject": "^4.0.6",
-				"lodash.isstring": "^4.0.1",
-				"lodash.once": "^4.0.0",
-				"ms": "^2.1.1",
-				"semver": "^5.6.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-				}
-			}
-		},
 		"jsprim": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -5087,19 +5081,6 @@
 				"jwa": "^2.0.0",
 				"safe-buffer": "^5.0.1"
 			}
-		},
-		"jwt-builder": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/jwt-builder/-/jwt-builder-1.1.0.tgz",
-			"integrity": "sha1-w+Czl30QljCN+dQDMPCEJhwYQ7k=",
-			"requires": {
-				"jwt-simple": "^0.5.0"
-			}
-		},
-		"jwt-simple": {
-			"version": "0.5.6",
-			"resolved": "https://registry.npmjs.org/jwt-simple/-/jwt-simple-0.5.6.tgz",
-			"integrity": "sha512-40aUybvhH9t2h71ncA1/1SbtTNCVZHgsTsTgqPUxGWDmUDrXyDf2wMNQKEbdBjbf4AI+fQhbECNTV6lWxQKUzg=="
 		},
 		"keytar": {
 			"version": "5.6.0",
@@ -5183,41 +5164,6 @@
 			"resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
 			"integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
 			"dev": true
-		},
-		"lodash.includes": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-			"integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
-		},
-		"lodash.isboolean": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-			"integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
-		},
-		"lodash.isinteger": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-			"integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
-		},
-		"lodash.isnumber": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-			"integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
-		},
-		"lodash.isplainobject": {
-			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-			"integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
-		},
-		"lodash.isstring": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-			"integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
-		},
-		"lodash.once": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-			"integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
 		},
 		"log-symbols": {
 			"version": "4.0.0",
@@ -6610,7 +6556,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/pupa/-/pupa-2.0.1.tgz",
 			"integrity": "sha512-hEJH0s8PXLY/cdXh66tNEQGndDrIKNqNC5xmrysZy3i5C3oEoLna7YAOad+7u125+zH1HNXUmGEkrhb3c2VriA==",
-			"dev": true,
 			"requires": {
 				"escape-goat": "^2.0.0"
 			}
@@ -7298,6 +7243,11 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
 			"integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+		},
+		"string-format-obj": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/string-format-obj/-/string-format-obj-1.1.1.tgz",
+			"integrity": "sha512-Mm+sROy+pHJmx0P/0Bs1uxIX6UhGJGj6xDGQZ5zh9v/SZRmLGevp+p0VJxV7lirrkAmQ2mvva/gHKpnF/pTb+Q=="
 		},
 		"string-width": {
 			"version": "1.0.2",

--- a/packages/laboratory/package.json
+++ b/packages/laboratory/package.json
@@ -60,6 +60,7 @@
     "express-async-errors": "^3.1.1",
     "passport": "^0.4.1",
     "passport-azure-ad": "^4.3.0",
+    "pupa": "^2.0.1",
     "reflect-metadata": "^0.1.13",
     "sequelize": "^5.22.3",
     "sequelize-typescript": "^1.1.0",

--- a/packages/laboratory/test/sequelize_laboratory/models/models.test.ts
+++ b/packages/laboratory/test/sequelize_laboratory/models/models.test.ts
@@ -1,5 +1,4 @@
 import { assert } from 'chai';
-import { Sequelize } from 'sequelize-typescript';
 
 import {
   Benchmark,
@@ -19,10 +18,8 @@ import { assertDeepEqual } from '../shared';
 import { initializeSequelize } from '../../../src/sequelize_laboratory';
 
 describe('sequelize', () => {
-  let sequelize: Sequelize;
-
   before(async () => {
-    sequelize = await initializeSequelize({
+    await initializeSequelize({
       dialect: 'sqlite',
       storage: ':memory:',
       logging: false,

--- a/packages/sds/src/laboratory/interfaces.ts
+++ b/packages/sds/src/laboratory/interfaces.ts
@@ -134,7 +134,6 @@ export const CandidateType = t.intersection([
     image: t.string,
   }),
   t.partial({
-    cmd: t.array(t.string),
     env: t.record(t.string, t.string),
   }),
 ]);

--- a/packages/sds/src/messages.ts
+++ b/packages/sds/src/messages.ts
@@ -1,19 +1,19 @@
 // Data contracts for queue messages
 
-export type PipelineRun = Readonly<{
+export type PipelineRun = {
   name: string;
   laboratoryEndpoint: string;
-  stages: ReadonlyArray<PipelineRunStage>;
+  stages: PipelineRunStage[];
   // TODO: consider elevating volumes to top-level property
-}>;
+};
 
 export interface PipelineRunStage {
   name: string;
   kind: string;
   image: string;
   cmd?: string[];
-  env?: Readonly<Record<string, string>>;
-  volumes?: ReadonlyArray<PipelineRunStageVolume>;
+  env?: Record<string, string>;
+  volumes?: PipelineRunStageVolume[];
 }
 
 export interface PipelineRunStageVolume {

--- a/packages/sds/test/laboratory/data.ts
+++ b/packages/sds/test/laboratory/data.ts
@@ -13,7 +13,7 @@ import {
   BenchmarkStageKind,
 } from '../../src';
 
-export const serviceURL = 'http://localhost:3000'; // TODO: plumb real url.
+export const serviceURL = 'http://localhost:3000';
 
 export const timestamps = {
   createdAt: new Date('2020-03-19T21:37:31.452Z'),
@@ -122,6 +122,120 @@ export const benchmark3: IBenchmark = {
   ...timestamps,
 };
 
+export const benchmark4: IBenchmark = {
+  name: 'benchmark4',
+  author: 'author4',
+  apiVersion: 'v1alpha1',
+  stages: [
+    {
+      name: 'prep',
+      kind: BenchmarkStageKind.CONTAINER,
+      image: 'benchmark4',
+      cmd: [
+        '--dataset',
+        '{suite.properties.datasetId}',
+        '--candidate-files',
+        '/data',
+        '--resources',
+        '/resources',
+        '--evaluation-files',
+        '/evaluation',
+      ],
+      env: {
+        MODE: 'prep',
+      },
+      volumes: [
+        {
+          name: 'candidateData',
+          path: '/data',
+          readonly: false,
+        },
+        {
+          name: 'resources',
+          path: '/resources',
+          readonly: false,
+        },
+
+        {
+          name: 'labels',
+          path: '/evaluation',
+          readonly: false,
+        },
+      ],
+    },
+    {
+      name: 'candidate',
+      kind: BenchmarkStageKind.CANDIDATE,
+      cmd: [
+        '--input',
+        '/data/input.json',
+        '--resources',
+        '/resources',
+        '--output',
+        '/output',
+      ],
+      env: {
+        SDS_RUN: '{run.name}',
+      },
+      volumes: [
+        {
+          name: 'candidateData',
+          path: '/data',
+          readonly: true,
+        },
+        {
+          name: 'resources',
+          path: '/resources',
+          readonly: true,
+        },
+        {
+          name: 'candidateOutput',
+          path: '/output',
+          readonly: false,
+        },
+      ],
+    },
+    {
+      name: 'scoring',
+      image: 'benchmark4',
+      kind: BenchmarkStageKind.CONTAINER,
+      cmd: [
+        '--expected',
+        '/expected/expected.json',
+        '--actual',
+        '/actual/actual.json',
+        '--resources',
+        '/resources',
+        '--laboratory',
+        '{laboratoryEndpoint}',
+        '--run',
+        '{run.name}',
+      ],
+      env: {
+        MODE: 'evaluation',
+      },
+      volumes: [
+        {
+          name: 'candidateOutput',
+          path: '/actual',
+          readonly: true,
+        },
+        {
+          name: 'labels',
+          path: '/expected',
+          readonly: true,
+        },
+        {
+          name: 'resources',
+          path: '/resources',
+          readonly: true,
+        },
+      ],
+    },
+  ],
+  ...timestamps,
+};
+
 export const candidate1: ICandidate = {
   name: 'candidate1',
   author: 'author1',
@@ -146,6 +260,18 @@ export const candidate3: ICandidate = {
   apiVersion: 'v1alpha1',
   benchmark: 'benchmark1',
   image: 'candidate3-image',
+  ...timestamps,
+};
+
+export const candidate4: ICandidate = {
+  name: 'candidate4',
+  author: 'author4',
+  apiVersion: 'v1alpha1',
+  benchmark: 'benchmark4',
+  image: 'candidate4-image',
+  env: {
+    LOG_LEVEL: 'debug',
+  },
   ...timestamps,
 };
 
@@ -207,6 +333,35 @@ export const suite3: ISuite = {
       name: 'reference',
       type: 'AzureBlob',
       target: 'https://sample.blob.core.windows.net/reference',
+    },
+  ],
+  ...timestamps,
+};
+
+export const suite4: ISuite = {
+  name: 'suite4',
+  author: 'author4',
+  apiVersion: 'v1alpha1',
+  benchmark: 'benchmark4',
+  properties: {
+    datasetId: '00000000-0000-0000-0000-000000000000',
+  },
+  volumes: [
+    {
+      name: 'candidateData',
+      type: 'ephemeral',
+    },
+    {
+      name: 'resources',
+      type: 'ephemeral',
+    },
+    {
+      name: 'labels',
+      type: 'ephemeral',
+    },
+    {
+      name: 'candidateOutput',
+      type: 'ephemeral',
     },
   ],
   ...timestamps,

--- a/packages/worker/src/argoWorker.ts
+++ b/packages/worker/src/argoWorker.ts
@@ -5,6 +5,7 @@ import {
   PipelineRun,
   BenchmarkStageKind,
 } from '@microsoft/sds';
+import { defaultClient } from 'applicationinsights';
 import { Workflow, Template, PersistentVolumeClaim } from './argo';
 import { ArgoWorkerConfiguration } from './configuration';
 
@@ -88,6 +89,15 @@ export function createWorkflow(
         name: e[0],
         value: e[1],
       }));
+    } else {
+      template.container!.env = [];
+    }
+
+    if (defaultClient.config.instrumentationKey) {
+      template.container!.env!.push({
+        name: 'APPINSIGHTS_INSTRUMENTATIONKEY',
+        value: defaultClient.config.instrumentationKey,
+      });
     }
 
     return template;

--- a/packages/worker/test/argoWorker.test.ts
+++ b/packages/worker/test/argoWorker.test.ts
@@ -78,6 +78,12 @@ describe('createWorkflow', () => {
             },
             container: {
               image: 'candidate',
+              env: [
+                {
+                  name: 'APPINSIGHTS_INSTRUMENTATIONKEY',
+                  value: '00000000-0000-0000-0000-000000000000',
+                },
+              ],
             },
           },
           {
@@ -89,6 +95,12 @@ describe('createWorkflow', () => {
             },
             container: {
               image: 'eval',
+              env: [
+                {
+                  name: 'APPINSIGHTS_INSTRUMENTATIONKEY',
+                  value: '00000000-0000-0000-0000-000000000000',
+                },
+              ],
             },
           },
         ],
@@ -173,6 +185,10 @@ describe('createWorkflow', () => {
                   name: 'SOME_CONFIG',
                   value: 'active',
                 },
+                {
+                  name: 'APPINSIGHTS_INSTRUMENTATIONKEY',
+                  value: '00000000-0000-0000-0000-000000000000',
+                },
               ],
             },
           },
@@ -190,6 +206,10 @@ describe('createWorkflow', () => {
                 {
                   name: 'MODE',
                   value: 'evaluation',
+                },
+                {
+                  name: 'APPINSIGHTS_INSTRUMENTATIONKEY',
+                  value: '00000000-0000-0000-0000-000000000000',
                 },
               ],
             },
@@ -335,6 +355,12 @@ describe('createWorkflow', () => {
             },
             container: {
               image: 'candidate',
+              env: [
+                {
+                  name: 'APPINSIGHTS_INSTRUMENTATIONKEY',
+                  value: '00000000-0000-0000-0000-000000000000',
+                },
+              ],
               volumeMounts: [
                 {
                   name: 'images',
@@ -358,6 +384,12 @@ describe('createWorkflow', () => {
             },
             container: {
               image: 'eval',
+              env: [
+                {
+                  name: 'APPINSIGHTS_INSTRUMENTATIONKEY',
+                  value: '00000000-0000-0000-0000-000000000000',
+                },
+              ],
               volumeMounts: [
                 {
                   name: 'predictions',
@@ -455,6 +487,12 @@ describe('createWorkflow', () => {
             },
             container: {
               image: 'candidate',
+              env: [
+                {
+                  name: 'APPINSIGHTS_INSTRUMENTATIONKEY',
+                  value: '00000000-0000-0000-0000-000000000000',
+                },
+              ],
               volumeMounts: [
                 {
                   name: 'images',

--- a/sample-data/benchmark1.yaml
+++ b/sample-data/benchmark1.yaml
@@ -15,8 +15,3 @@ stages:
       - name: reference
         path: /reference
         readonly: true
-volumes:
-  - name: training
-    type: ephemeral
-  - name: reference
-    type: ephemeral

--- a/samples/catdetection/benchmark.yml
+++ b/samples/catdetection/benchmark.yml
@@ -31,10 +31,3 @@ stages:
     path: /scores
     readonly: false
 
-volumes:
-- name: images
-  type: ephemeral
-- name: predictions
-  type: ephemeral
-- name: scores
-  type: scores


### PR DESCRIPTION
Laboratory

* Uses [pupa](https://www.npmjs.com/package/pupa) to map values from the run into the a container's command-line arguments and/or environment variables
* Removes `Readonly` from queue message - it was making construction too verbose. Users can still wrap a fully-formed `PipelineRun` in `Readonly<>` if they truly need to work with a readonly object

Worker

* Maps `APPINSIGHTS_INSTRUMETNATIONKEY` to all containers

Other

* Removes `volumes` property that doesn't exist on `IBenchmark` in YAML files
* Minor test var/import cleanup