### PR TITLE
Remove diagnostic settings from arm templates

### DIFF
--- a/deploy/arm/azuredeploy.json
+++ b/deploy/arm/azuredeploy.json
@@ -106,12 +106,6 @@
         "parameters": {
           "tags": {
             "value": "[parameters('tags')]"
-          },
-          "monitoringEventHub": {
-            "value": "[reference(resourceId('Microsoft.Resources/deployments', 'monitoring')).outputs.eventHub.value]"
-          },
-          "monitoringEventHubsNamespace": {
-            "value": "[reference(resourceId('Microsoft.Resources/deployments', 'monitoring')).outputs.eventHubsNamespace.value]"
           }
         },
         "templateLink": {
@@ -210,15 +204,6 @@
           "keyVault": {
             "value": "[reference(resourceId('Microsoft.Resources/deployments', 'keyvault')).outputs.keyVault.value]"
           },
-          "monitoringStorageAccount": {
-            "value": "[reference(resourceId('Microsoft.Resources/deployments', 'monitoring')).outputs.storageAccount.value]"
-          },
-          "monitoringEventHub": {
-            "value": "[reference(resourceId('Microsoft.Resources/deployments', 'monitoring')).outputs.eventHub.value]"
-          },
-          "monitoringEventHubsNamespace": {
-            "value": "[reference(resourceId('Microsoft.Resources/deployments', 'monitoring')).outputs.eventHubsNamespace.value]"
-          },
           "authMode": {
             "value": "[parameters('authMode')]"
           },
@@ -280,7 +265,6 @@
     {
       "dependsOn": [
         "[resourceId('Microsoft.Resources/deployments', 'network')]",
-        "[resourceId('Microsoft.Resources/deployments', 'monitoring')]",
         "[resourceId('Microsoft.Resources/deployments', 'firewall')]"
       ],
       "type": "Microsoft.Resources/deployments",
@@ -299,9 +283,6 @@
           },
           "tags": {
             "value": "[parameters('tags')]"
-          },
-          "logAnalyticsWorkspace": {
-            "value": "[reference(resourceId('Microsoft.Resources/deployments', 'monitoring')).outputs.logAnalyticsWorkspace.value]"
           }
         },
         "templateLink": {

--- a/deploy/arm/laboratory.json
+++ b/deploy/arm/laboratory.json
@@ -28,15 +28,6 @@
     "keyVault": {
       "type": "string"
     },
-    "monitoringStorageAccount": {
-      "type": "string"
-    },
-    "monitoringEventHub": {
-      "type": "string"
-    },
-    "monitoringEventHubsNamespace": {
-      "type": "string"
-    },
     "authMode": {
       "type": "string",
       "defaultValue": "none"
@@ -67,12 +58,6 @@
     "diagnosticsLogs": "diagnosticslogs",
     "infraAcrName": "[last(split(parameters('infraAcrId'), '/'))]",
     "laboratory": "laboratory",
-    "monitoringBlobSAS": {
-      "canonicalizedResource": "[format('/blob/{0}/{1}', parameters('monitoringStorageAccount'), variables('diagnosticsLogs'))]",
-      "signedExpiry": "2050-01-01T00:00:00Z",
-      "signedPermission": "dlrw",
-      "signedProtocol": "https"
-    },
     "sqlAdminUsername": "laboratory",
     "sqlEncryptionKey": "laboratorySql",
     "sqlServer": "[concat('laboratory', variables('suffix'))]",
@@ -97,38 +82,6 @@
       "location": "[resourceGroup().location]",
       "name": "[variables('laboratory')]",
       "tags": "[parameters('tags')]"
-    },
-    {
-      "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
-      "apiVersion": "2019-06-01",
-      "location": "[resourceGroup().location]",
-      "name": "[concat(parameters('monitoringStorageAccount'), '/default/', variables('vulnerabilityAssessments'))]",
-      "properties": {
-        "publicAccess": "None"
-      }
-    },
-    {
-      "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
-      "apiVersion": "2019-06-01",
-      "location": "[resourceGroup().location]",
-      "name": "[concat(parameters('monitoringStorageAccount'), '/default/', variables('diagnosticsLogs'))]",
-      "properties": {
-        "publicAccess": "None"
-      }
-    },
-    {
-      "dependsOn": [
-        "[resourceId('Microsoft.Sql/servers', variables('sqlServer'))]"
-      ],
-      "type": "Microsoft.Storage/storageAccounts/providers/roleAssignments",
-      "apiVersion": "2018-09-01-preview",
-      "location": "[resourceGroup().location]",
-      "name": "[concat(parameters('monitoringStorageAccount'), '/Microsoft.Authorization/', guid(concat(resourceGroup().id, variables('sqlServer'), parameters('monitoringStorageAccount'), 'StorageBlobDataContributor')))]",
-      "properties": {
-        "principalId": "[reference(resourceId('Microsoft.Sql/servers', variables('sqlServer')), '2019-06-01-preview', 'Full').identity.principalId]",
-        "roleDefinitionId": "[variables('storageBlobDataContributorRoleId')]",
-        "principalType": "ServicePrincipal"
-      }
     },
     {
       "type": "Microsoft.Sql/servers",
@@ -172,104 +125,7 @@
             "tier": "Standard"
           },
           "properties": {
-          },
-          "resources": [
-            {
-              "dependsOn": [
-                "[resourceId('Microsoft.Sql/servers/databases', variables('sqlServer'), variables('laboratory'))]"
-              ],
-              "type": "providers/diagnosticSettings",
-              "apiVersion": "2017-05-01-preview",
-              "location": "[resourceGroup().location]",
-              "name": "Microsoft.Insights/diagnostics",
-              "properties": {
-                "eventHubName": "[parameters('monitoringEventHub')]",
-                "eventHubAuthorizationRuleId": "[resourceId('Microsoft.EventHub/namespaces/authorizationrules', parameters('monitoringEventHubsNamespace'), 'RootManageSharedAccessKey')]",
-                "logs": [
-                  {
-                    "category": "SQLInsights",
-                    "enabled": true,
-                    "retentionPolicy": {
-                      "days": 365,
-                      "enabled": true
-                    }
-                  },
-                  {
-                    "category": "AutomaticTuning",
-                    "enabled": true,
-                    "retentionPolicy": {
-                      "days": 365,
-                      "enabled": true
-                    }
-                  },
-                  {
-                    "category": "QueryStoreRuntimeStatistics",
-                    "enabled": true,
-                    "retentionPolicy": {
-                      "days": 365,
-                      "enabled": true
-                    }
-                  },
-                  {
-                    "category": "QueryStoreWaitStatistics",
-                    "enabled": true,
-                    "retentionPolicy": {
-                      "days": 365,
-                      "enabled": true
-                    }
-                  },
-                  {
-                    "category": "Errors",
-                    "enabled": true,
-                    "retentionPolicy": {
-                      "days": 365,
-                      "enabled": true
-                    }
-                  },
-                  {
-                    "category": "DatabaseWaitStatistics",
-                    "enabled": true,
-                    "retentionPolicy": {
-                      "days": 365,
-                      "enabled": true
-                    }
-                  },
-                  {
-                    "category": "Timeouts",
-                    "enabled": true,
-                    "retentionPolicy": {
-                      "days": 365,
-                      "enabled": true
-                    }
-                  },
-                  {
-                    "category": "Blocks",
-                    "enabled": true,
-                    "retentionPolicy": {
-                      "days": 365,
-                      "enabled": true
-                    }
-                  },
-                  {
-                    "category": "Deadlocks",
-                    "enabled": true,
-                    "retentionPolicy": {
-                      "days": 365,
-                      "enabled": true
-                    }
-                  },
-                  {
-                    "category": "SQLSecurityAuditEvents",
-                    "enabled": true,
-                    "retentionPolicy": {
-                      "days": 365,
-                      "enabled": true
-                    }
-                  }
-                ]
-              }
-            }
-          ]
+          }
         },
         {
           "dependsOn": [
@@ -297,39 +153,6 @@
             "state": "Enabled",
             "emailAccountAdmins": true,
             "emailAddresses": "[variables('adminEmailAddresses')]"
-          }
-        },
-        {
-          "dependsOn": [
-            "[resourceId('Microsoft.Sql/servers', variables('sqlServer'))]",
-            "[extensionResourceId(resourceId('Microsoft.Storage/storageAccounts', parameters('monitoringStorageAccount')), 'Microsoft.Authorization/roleAssignments', guid(concat(resourceGroup().id, variables('sqlServer'), parameters('monitoringStorageAccount'), 'StorageBlobDataContributor')))]"
-          ],
-          "type": "auditingSettings",
-          "apiVersion": "2017-03-01-preview",
-          "name": "default",
-          "properties": {
-            "state": "Enabled",
-            "retentionDays": 365,
-            "storageEndpoint": "[reference(resourceId('Microsoft.Storage/storageAccounts', parameters('monitoringStorageAccount')), '2019-06-01').primaryEndpoints.blob]"
-          }
-        },
-        {
-          "dependsOn": [
-            "[resourceId('Microsoft.Sql/servers', variables('sqlServer'))]",
-            "[resourceId('Microsoft.Storage/storageAccounts/blobServices/containers', parameters('monitoringStorageAccount'), 'default', variables('vulnerabilityAssessments'))]",
-            "[extensionResourceId(resourceId('Microsoft.Storage/storageAccounts', parameters('monitoringStorageAccount')), 'Microsoft.Authorization/roleAssignments', guid(concat(resourceGroup().id, variables('sqlServer'), parameters('monitoringStorageAccount'), 'StorageBlobDataContributor')))]"
-          ],
-          "type": "vulnerabilityAssessments",
-          "apiVersion": "2018-06-01-preview",
-          "location": "[resourceGroup().location]",
-          "name": "default",
-          "properties": {
-            "storageContainerPath": "[concat(reference(resourceId('Microsoft.Storage/storageAccounts', parameters('monitoringStorageAccount')), '2019-06-01').primaryEndpoints.blob, variables('vulnerabilityAssessments'))]",
-            "recurringScans": {
-              "isEnabled": true,
-              "emailSubscriptionAdmins": true,
-              "emails": "[variables('adminEmailAddresses')]"
-            }
           }
         }
       ]
@@ -636,39 +459,6 @@ $DeploymentScriptOutputs['keyUrl'] = $key.Id
             "DOCKER_ENABLE_CI": "true",
             "WEBSITES_ENABLE_APP_SERVICE_STORAGE": "false",
             "WEBSITES_PORT": "3000"
-          }
-        },
-        {
-          "dependsOn": [
-            "[resourceId('Microsoft.Web/sites', variables('webApp'))]",
-            "[resourceId('Microsoft.Web/sites/config', variables('webApp'), 'appsettings')]",
-            "[resourceId('Microsoft.Storage/storageAccounts/blobServices/containers', parameters('monitoringStorageAccount'), 'default', variables('diagnosticsLogs'))]"
-          ],
-          "type": "config",
-          "apiVersion": "2019-08-01",
-          "location": "[resourceGroup().location]",
-          "name": "logs",
-          "properties": {
-            "applicationLogs": {
-              "azureBlobStorage": {
-                "level": "Error",
-                "sasUrl": "[concat(reference(resourceId('Microsoft.Storage/storageAccounts', parameters('monitoringStorageAccount')), '2019-06-01').primaryEndpoints.blob, variables('diagnosticsLogs'), listServiceSas(resourceId('Microsoft.Storage/storageAccounts', parameters('monitoringStorageAccount')), '2019-06-01', variables('monitoringBlobSAS')).serviceSasToken)]",
-                "retentionInDays": 365
-              }
-            },
-            "httpLogs": {
-              "azureBlobStorage": {
-                "sasUrl": "[concat(reference(resourceId('Microsoft.Storage/storageAccounts', parameters('monitoringStorageAccount')), '2019-06-01').primaryEndpoints.blob, variables('diagnosticsLogs'), listServiceSas(resourceId('Microsoft.Storage/storageAccounts', parameters('monitoringStorageAccount')), '2019-06-01', variables('monitoringBlobSAS')).serviceSasToken)]",
-                "retentionInDays": 365,
-                "enabled": true
-              }
-            },
-            "failedRequestsTracing": {
-              "enabled": true
-            },
-            "detailedErrorMessages": {
-              "enabled": true
-            }
           }
         }
       ]

--- a/deploy/arm/monitoring.json
+++ b/deploy/arm/monitoring.json
@@ -9,90 +9,17 @@
   },
   "variables": {
     "appInsights": "[concat('sds', variables('suffix'))]",
-    "eventHub": "diagnostics",
-    "eventHubsNamespace": "[concat('sds', variables('suffix'))]",
-    "logAnalytics": "[concat('sds', variables('suffix'))]",
-    "storageAccount": "[concat('audit', variables('suffix'))]",
     "suffix": "[toLower(take(uniqueString(resourceGroup().id), 6))]"
   },
   "resources": [
     {
-      "type": "Microsoft.OperationalInsights/workspaces",
-      "apiVersion": "2020-03-01-preview",
-      "location": "[resourceGroup().location]",
-      "name": "[variables('logAnalytics')]",
-      "tags": "[parameters('tags')]",
-      "properties": {
-        "features": {
-          "enableLogAccessUsingOnlyResourcePermissions": true
-        },
-        "retentionInDays": 120,
-        "sku": {
-          "name": "PerGB2018"
-        }
-      }
-    },
-    {
-      "dependsOn": [
-        "[resourceId('Microsoft.OperationalInsights/workspaces', variables('logAnalytics'))]"
-      ],
       "type": "Microsoft.Insights/components",
       "apiVersion": "2020-02-02-preview",
       "location": "[resourceGroup().location]",
       "name": "[variables('appInsights')]",
       "tags": "[parameters('tags')]",
       "properties": {
-        "Application_Type": "web",
-        "WorkspaceResourceId": "[resourceId('Microsoft.OperationalInsights/workspaces', variables('logAnalytics'))]"
-      }
-    },
-    {
-      "type": "Microsoft.EventHub/namespaces",
-      "apiVersion": "2018-01-01-preview",
-      "location": "[resourceGroup().location]",
-      "name": "[variables('eventHubsNamespace')]",
-      "sku": {
-        "capacity": 1,
-        "name": "Standard",
-        "tier": "Standard"
-      },
-      "tags": "[parameters('tags')]",
-      "properties": {
-      },
-      "resources": [
-        {
-          "dependsOn": [
-            "[resourceId('Microsoft.EventHub/namespaces', variables('eventHubsNamespace'))]"
-          ],
-          "type": "eventhubs",
-          "apiVersion": "2017-04-01",
-          "location": "[resourceGroup().location]",
-          "name": "[variables('eventHub')]",
-          "properties": {
-            "messageRetentionInDays": 7,
-            "partitionCount": 1
-          }
-        }
-      ]
-    },
-    {
-      "type": "Microsoft.Storage/storageAccounts",
-      "apiVersion": "2019-06-01",
-      "location": "[resourceGroup().location]",
-      "name": "[variables('storageAccount')]",
-      "kind": "StorageV2",
-      "sku": {
-        "name": "Standard_LRS"
-      },
-      "tags": "[parameters('tags')]",
-      "properties": {
-        "accessTier": "Hot",
-        "networkAcls": {
-          "bypass": "AzureServices",
-          "defaultAction": "Deny",
-          "virtualNetworkRules": []
-        },
-        "supportsHttpsTrafficOnly": true
+        "Application_Type": "web"
       }
     }
   ],
@@ -100,22 +27,6 @@
     "instrumentationKey": {
       "type": "string",
       "value": "[reference(resourceId('Microsoft.Insights/components', variables('appInsights'))).InstrumentationKey]"
-    },
-    "storageAccount": {
-      "type": "string",
-      "value": "[variables('storageAccount')]"
-    },
-    "eventHub": {
-      "type": "string",
-      "value": "[variables('eventHub')]"
-    },
-    "eventHubsNamespace": {
-      "type": "string",
-      "value": "[variables('eventHubsNamespace')]"
-    },
-    "logAnalyticsWorkspace": {
-      "type": "string",
-      "value": "[variables('logAnalytics')]"
     }
   }
 }

--- a/deploy/arm/network.json
+++ b/deploy/arm/network.json
@@ -5,12 +5,6 @@
     "tags": {
       "type": "object",
       "defaultValue": {}
-    },
-    "monitoringEventHub": {
-      "type": "string"
-    },
-    "monitoringEventHubsNamespace": {
-      "type": "string"
     }
   },
   "variables": {
@@ -110,39 +104,7 @@
             }
           }
         ]
-      },
-      "resources": [
-        {
-          "dependsOn": [
-            "[resourceId('Microsoft.Network/networkSecurityGroups', variables('privateLink'))]"
-          ],
-          "type": "providers/diagnosticSettings",
-          "apiVersion": "2017-05-01-preview",
-          "name": "[concat('Microsoft.Insights/diagnostics')]",
-          "properties": {
-            "eventHubName": "[parameters('monitoringEventHub')]",
-            "eventHubAuthorizationRuleId": "[resourceId('Microsoft.EventHub/namespaces/authorizationrules', parameters('monitoringEventHubsNamespace'), 'RootManageSharedAccessKey')]",
-            "logs": [
-              {
-                "category": "NetworkSecurityGroupEvent",
-                "enabled": true,
-                "retentionPolicy": {
-                  "days": 365,
-                  "enabled": true
-                }
-              },
-              {
-                "category": "NetworkSecurityGroupRuleCounter",
-                "enabled": true,
-                "retentionPolicy": {
-                  "days": 365,
-                  "enabled": true
-                }
-              }
-            ]
-          }
-        }
-      ]
+      }
     },
     {
       "dependsOn": [

--- a/deploy/arm/worker.json
+++ b/deploy/arm/worker.json
@@ -11,9 +11,6 @@
     "tags": {
       "type": "object",
       "defaultValue": {}
-    },
-    "logAnalyticsWorkspace": {
-      "type": "string"
     }
   },
   "variables": {
@@ -96,12 +93,6 @@
         "addonProfiles": {
           "kubeDashboard": {
             "enabled": false
-          },
-          "omsagent": {
-            "enabled": true,
-            "config": {
-              "logAnalyticsWorkspaceResourceId": "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('logAnalyticsWorkspace'))]"
-            }
           }
         }
       }


### PR DESCRIPTION
Logs & telemetry vary widely across deployments

Removing these for now, and they can be configured in a follow-up template / command.  These will likely return in a different form as a parameterized option w/ possible values "None, AzureMonitor, EventHubs, AzureStorage", and so on